### PR TITLE
initial workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ cabal.project.local~
 
 # nix result files
 /result*
+
+# .nix files generated from purenix
+/generated/

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ spago build --verbose
     For instance, `./purescript-cabal-parser/src/Main.purs` will be compiled to
     `./purescript-cabal-parser/output/Main/corefn.json`.
 
-3.  `spago` will try to run the `backend` command in
+3.  `spago` will try to run the `backend` command defined in
     `./purescript-cabal-parser/spago.dhall`.
 
     This is set to `cd ../purenix && cabal run purenix`, so the `purenix`
@@ -53,3 +53,15 @@ $ spago build --verbose
 4.  `purenix` needs to look for all `corefn.json` files in
     `./purescript-cabal-parser/output/`, translate them to JSON, and then
     output them somewhere.
+
+    It also needs to take into account the optional FFI files for each PureScript module.
+
+    For instance, if `./purescript-cabal-parser/src/Main.purs` defines FFI
+    functions, there needs to be a corresponding
+    `./purescript-cabal-parser/src/Main.nix` file.
+
+    Note that `spago build` does not copy this
+    `./purescript-cabal-parser/src/Main.nix` file to
+    `./purescript-cabal-parser/output/` for us, so we need to explicitly look
+    for `./purescript-cabal-parser/src/Main.nix` in `purenix`.  I haven't yet
+    looked at how other PureScript backends handle this.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
 # cabal2nixWithoutIFD
+
+This is a proof-of-concept for a
+[`cabal2nix`](https://github.com/NixOS/cabal2nix) written in Nix. The benefit
+of writting it in Nix instead of Haskell is that is can parse a `.cabal` file
+directly.  It does not rely on
+[Import From Derivation (IFD)](https://blog.hercules-ci.com/2019/08/30/native-support-for-import-for-derivation/)
+to work.
+
+Internally we have a PureScript backend that compiles to Nix called
+[`purenix`](./purenix).  We have written a `.cabal` parser in
+PureScript in [`purescript-cabal-parser`](./purescript-cabal-parser) and
+compiled it to Nix.  We can then directly use this from Nix to parse
+a `.cabal` file without IFD.
+
+## Running
+
+Compiling `purescript-cabal-parser` to Nix can be done with the following
+steps.
+
+First, get into a Nix devShell:
+
+```console
+$ nix develop
+```
+
+The, change to `./purescript-cabal-parser` directory and run `spago build`:
+
+```console
+$ cd ./purescript-cabal-parser
+$ spago build --verbose
+```
+
+`spago build` does the following things:
+
+1.  Looks for all `.purs` files in `./purescript-cabal-parser/src/`.
+
+    The location to search for `.purs` files can be changed in
+    `./purescript-cabal-parser/spago.dhall`.
+
+2.  Compile the `.purs` files to corefn and output in
+    `./purescript-cabal-parser/output/`.
+
+    For instance, `./purescript-cabal-parser/src/Main.purs` will be compiled to
+    `./purescript-cabal-parser/output/Main/corefn.json`.
+
+3.  `spago` will try to run the `backend` command in
+    `./purescript-cabal-parser/spago.dhall`.
+
+    This is set to `cd ../purenix && cabal run purenix`, so the `purenix`
+    executable will be built and run.
+
+4.  `purenix` needs to look for all `corefn.json` files in
+    `./purescript-cabal-parser/output/`, translate them to JSON, and then
+    output them somewhere.

--- a/flake.nix
+++ b/flake.nix
@@ -45,10 +45,10 @@
         flake = pkgs.hsPkgs.flake { };
       in
       flake // {
-        defaultPackage = flake.packages."purenix:exe:purenix-exe";
+        defaultPackage = flake.packages."purenix:exe:purenix";
 
         devShell = flake.devShell.overrideAttrs (oldAttrs: {
-          nativeBuildInputs = (oldAttrs.nativeBuildInputs or []) ++ [
+          nativeBuildInputs = (oldAttrs.nativeBuildInputs or [ ]) ++ [
             pkgs.purescript
             pkgs.spago
           ];

--- a/purenix/app/Main.hs
+++ b/purenix/app/Main.hs
@@ -1,4 +1,4 @@
 import Lib
 
 main :: IO ()
-main = putStrLn "heyyyyyy"
+main = defaultMain

--- a/purenix/hie.yaml
+++ b/purenix/hie.yaml
@@ -7,7 +7,7 @@ cradle:
       config: {cradle: {cabal: {component: "lib:purenix"}}}
 
     - path: "app"
-      config: {cradle: {cabal: {component: "purenix:purenix-exe"}}}
+      config: {cradle: {cabal: {component: "purenix:purenix"}}}
 
     - path: "test"
       config: {cradle: {cabal: {component: "purenix:purenix-test"}}}

--- a/purenix/purenix.cabal
+++ b/purenix/purenix.cabal
@@ -11,7 +11,7 @@ author:          Dennis Gosnell, Jonas Carpay
 maintainer:      Dennis Gosnell <cdep.illabout@gmail.com>
 copyright:       2021 Dennis Gosnell, Jonas Carpay
 homepage:        https://github.com/cdepillabout/cabal2nixWithoutIFD
-tested-with:     GHC ==8.6.3 || ==8.8.3 || ==8.10.5
+tested-with:     GHC ==8.10.4
 extra-doc-files:
   CHANGELOG.md
   README.md
@@ -33,11 +33,15 @@ library
   hs-source-dirs:  src
   exposed-modules: Lib
   build-depends:
+    , aeson
     , containers
+    , directory
     , mtl
     , purescript  ==0.14.4
+    , pretty-simple
+    , text
 
-executable purenix-exe
+executable purenix
   import:         common-options
   hs-source-dirs: app
   main-is:        Main.hs

--- a/purenix/src/Lib.hs
+++ b/purenix/src/Lib.hs
@@ -1,7 +1,29 @@
-module Lib
-  ( someFunc,
-  )
-where
+module Lib where
 
-someFunc :: IO ()
-someFunc = putStrLn "hey"
+import Data.Aeson (decode)
+import Data.Aeson.Types (parseEither)
+import Data.Text.Lazy (pack)
+import Data.Text.Lazy.Encoding (encodeUtf8)
+import Language.PureScript.CoreFn.FromJSON (moduleFromJSON)
+import System.Directory (createDirectoryIfMissing)
+import Text.Pretty.Simple (pPrint)
+
+defaultMain :: IO ()
+defaultMain = do
+  corefn <- readFile "../purescript-cabal-parser/output/Main/corefn.json"
+  let maybeValue = decode $ encodeUtf8 $ pack corefn
+  case maybeValue of
+    Nothing -> error "wasn't able to decode corefn as json"
+    Just value -> do
+      let eitherModule = parseEither moduleFromJSON value
+      case eitherModule of
+        Left err -> error err
+        Right (version, mdl) -> do
+          putStrLn "successfully decoded purescript module"
+          pPrint mdl
+
+          -- TODO: Transform the purescript module into a .nix file
+          createDirectoryIfMissing True "../generated"
+          putStrLn "writing ../generated/Main.nix"
+          writeFile "../generated/Main.nix" "{ myId = a: a; myNum = 3; }"
+

--- a/purescript-cabal-parser/spago.dhall
+++ b/purescript-cabal-parser/spago.dhall
@@ -11,7 +11,17 @@ When creating a new Spago project, you can use
 to generate this file without the comments in this block.
 -}
 { name = "cabal-parser"
-, dependencies = [ "console", "effect", "prelude", "psci-support" ]
-, packages = ./packages.dhall
-, sources = [ "src/**/*.purs", "test/**/*.purs" ]
+
+-- , dependencies = [ "console", "effect", "prelude", "psci-support" ]
+, dependencies = [] : List Text
+
+-- , packages = ./packages.dhall
+, packages = {=}
+
+, backend = "cd ../purenix && cabal run"
+
+, sources =
+    [ "src/**/*.purs"
+    -- , "test/**/*.purs"
+    ]
 }

--- a/purescript-cabal-parser/spago.dhall
+++ b/purescript-cabal-parser/spago.dhall
@@ -18,7 +18,7 @@ to generate this file without the comments in this block.
 -- , packages = ./packages.dhall
 , packages = {=}
 
-, backend = "cd ../purenix && cabal run"
+, backend = "cd ../purenix && cabal run purenix"
 
 , sources =
     [ "src/**/*.purs"

--- a/purescript-cabal-parser/src/Main.nix
+++ b/purescript-cabal-parser/src/Main.nix
@@ -1,0 +1,2 @@
+
+{ mySubstring = builtins.substring; }

--- a/purescript-cabal-parser/src/Main.purs
+++ b/purescript-cabal-parser/src/Main.purs
@@ -1,10 +1,16 @@
 module Main where
 
-import Prelude
+-- import Prelude
 
-import Effect (Effect)
-import Effect.Console (log)
+-- import Effect (Effect)
+-- import Effect.Console (log)
 
-main :: Effect Unit
-main = do
-  log "🍝"
+-- main :: Effect Unit
+-- main = do
+--   log "🍝"
+
+myId :: forall a. a -> a
+myId a = a
+
+myNum :: Int
+myNum = 3

--- a/purescript-cabal-parser/src/Main.purs
+++ b/purescript-cabal-parser/src/Main.purs
@@ -14,3 +14,9 @@ myId a = a
 
 myNum :: Int
 myNum = 3
+
+foreign import mySubstring :: Int -> Int -> String -> String
+
+-- | Output the string `"nix"`.
+useMySubstring :: String
+useMySubstring = mySubstring 0 3 "nixos"


### PR DESCRIPTION
This PR defines an initial workflow so we can get started with translating PureScript to Nix.

The summary is that you need to jump into `nix develop`, and then `cd purescript-cabal-to-nix && spago build`.  This compiles our PureScript files to corefn, and calls `purenix`.