### PR TITLE
Various modifications on codegen

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
 
         devShell = flake.devShell.overrideAttrs (oldAttrs: {
           nativeBuildInputs = (oldAttrs.nativeBuildInputs or [ ]) ++ [
-            pkgs.purescript
+            pkgs.hsPkgs.hsPkgs.purescript.components.exes.purs
             pkgs.spago
           ];
         });

--- a/purenix/purenix.cabal
+++ b/purenix/purenix.cabal
@@ -36,6 +36,7 @@ library
   other-modules:
     Nix.Convert
     Nix.Expr
+    Nix.Prelude
     Nix.Print
 
   build-depends:

--- a/purenix/purenix.cabal
+++ b/purenix/purenix.cabal
@@ -38,6 +38,7 @@ library
     Nix.Expr
     Nix.Prelude
     Nix.Print
+    Nix.Util
 
   build-depends:
     , aeson

--- a/purenix/src/Lib.hs
+++ b/purenix/src/Lib.hs
@@ -1,4 +1,8 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 module Lib where
+
+import Nix.Prelude
 
 import Data.Aeson (decode)
 import Data.Aeson.Types (parseEither)

--- a/purenix/src/Nix/Convert.hs
+++ b/purenix/src/Nix/Convert.hs
@@ -141,7 +141,13 @@ checkKeyword w
 attrs :: [(PSString, Expr Ann)] -> Convert N.Expr
 attrs = fmap (N.attrs [] []) . traverse attr
   where
-    attr (string, body) = (P.prettyPrintString string,) <$> expr body
+    attr (string, body) = (strWithoutQuotes string,) <$> expr body
+
+    -- P.prettyPrintString generates strings with quotes around them.
+    -- However, the purenix pretty-printer adds strings when necessary,
+    -- so we drop the quotes here.
+    strWithoutQuotes :: PSString -> Text
+    strWithoutQuotes = T.dropEnd 1 . T.drop 1 . P.prettyPrintString
 
 literal :: Literal (Expr Ann) -> Convert N.Expr
 literal (NumericLiteral (Left n)) = pure $ N.num n

--- a/purenix/src/Nix/Convert.hs
+++ b/purenix/src/Nix/Convert.hs
@@ -14,6 +14,7 @@ import Language.PureScript.CoreFn
 import Language.PureScript.Errors (SourceSpan)
 import Language.PureScript.PSString (PSString)
 import qualified Nix.Expr as N
+import Nix.Util (nixKeywords)
 
 type Convert = ReaderT (FilePath, SourceSpan) (Either Text)
 
@@ -108,10 +109,6 @@ checkKeyword w
   where
     -- These idents have a special meaning in purenix.
     purenixIdents = ["modules"]
-    -- keywords in nix:
-    -- https://github.com/NixOS/nix/blob/90b2dd570cbd8313a8cf45b3cf66ddef2bb06e07/src/libexpr/lexer.l#L115-L124
-    nixKeywords =
-      ["if", "then", "else", "assert", "with", "let", "in", "rec", "inherit", "or"]
     -- primops (builtins) in Nix that can be accessed without importing anything.
     -- These were discovered by running `nix repl` and hitting TAB.
     nixPrimops =

--- a/purenix/src/Nix/Convert.hs
+++ b/purenix/src/Nix/Convert.hs
@@ -89,6 +89,13 @@ expr Constructor {} = throw "Cannot yet convert constructors"
 
 ident :: Ident -> Convert N.Ident
 ident (Ident i) = pure i
+-- GenIdent is only used in PureScript for "unnamed" instances.
+-- Originally, in PureScript, all instances needed to be named:
+-- https://github.com/purescript/documentation/blob/master/language/Differences-from-Haskell.md#named-instances
+-- This was relaxed in 0.14.2:
+-- https://github.com/purescript/purescript/pull/4096
+-- TODO: We'll have to make sure that no identifier are created that are _only_
+-- an integer (when mname is Nothing), since they can't be used in Nix.
 ident (GenIdent mname n) = pure $ maybe id mappend mname (T.pack $ show n)
 ident UnusedIdent = throw "Impossible: Encountered typechecking-only identifier"
 

--- a/purenix/src/Nix/Convert.hs
+++ b/purenix/src/Nix/Convert.hs
@@ -1,15 +1,12 @@
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections #-}
 
 module Nix.Convert (convert) where
 
-import Control.Applicative
-import Control.Monad.Except
-import Control.Monad.Reader
-import Data.Bool (bool)
-import Data.Map
+import Nix.Prelude
+
 import qualified Data.Map as M
-import Data.Text (Text)
 import qualified Data.Text as T
 import Language.PureScript (Ident (..))
 import qualified Language.PureScript as P

--- a/purenix/src/Nix/Expr.hs
+++ b/purenix/src/Nix/Expr.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 
 module Nix.Expr where
 
-import Data.Map (Map)
-import Data.Text (Text)
+import Nix.Prelude
 
 type Ident = Text
 

--- a/purenix/src/Nix/Prelude.hs
+++ b/purenix/src/Nix/Prelude.hs
@@ -12,6 +12,7 @@ import Control.Monad.Reader as X
 import Control.Monad.State as X
 import Data.Bool as X (bool)
 import Data.Map as X (Map)
+import Data.Maybe as X (fromMaybe)
 import Data.String as X (IsString (..))
 import Data.Text as X (Text)
 import qualified Data.Text.Lazy as LT

--- a/purenix/src/Nix/Prelude.hs
+++ b/purenix/src/Nix/Prelude.hs
@@ -1,0 +1,19 @@
+
+module Nix.Prelude
+  ( module X
+  , LText
+  ) where
+
+import Prelude as X
+
+import Control.Applicative as X
+import Control.Monad.Except as X
+import Control.Monad.Reader as X
+import Control.Monad.State as X
+import Data.Bool as X (bool)
+import Data.Map as X (Map)
+import Data.String as X (IsString (..))
+import Data.Text as X (Text)
+import qualified Data.Text.Lazy as LT
+
+type LText = LT.Text

--- a/purenix/src/Nix/Print.hs
+++ b/purenix/src/Nix/Print.hs
@@ -1,17 +1,14 @@
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Nix.Print (renderExpr) where
 
-import Control.Monad.Reader
-import Control.Monad.State
-import Data.Bool (bool)
+import Nix.Prelude
+
 import Data.Char (isAlphaNum)
 import Data.List (intersperse)
 import Data.Semigroup (mtimesDefault)
-import Data.String (IsString (..))
-import Data.Text (Text)
 import qualified Data.Text as T
-import qualified Data.Text.Lazy as TL
 import Data.Text.Lazy.Builder (Builder)
 import qualified Data.Text.Lazy.Builder as TB
 import Nix.Expr hiding (string)
@@ -22,7 +19,7 @@ newtype PrintState = PrintState {psBuilder :: Builder}
 
 newtype Printer = Printer {_unPrinter :: ReaderT PrintContext (State PrintState) ()}
 
-runPrinter :: Printer -> TL.Text
+runPrinter :: Printer -> LText
 runPrinter (Printer p) = TB.toLazyText $ psBuilder $ execState (runReaderT p pc0) ps0
   where
     pc0 = PrintContext 0
@@ -65,7 +62,7 @@ newline = Printer $ do
   i <- asks pcIndent
   emit ("\n" <> mtimesDefault i " ")
 
-renderExpr :: Expr -> TL.Text
+renderExpr :: Expr -> LText
 renderExpr = runPrinter . fst3 . foldExpr render
   where
     fst3 (a, _, _) = a

--- a/purenix/src/Nix/Print.hs
+++ b/purenix/src/Nix/Print.hs
@@ -12,6 +12,7 @@ import qualified Data.Text as T
 import Data.Text.Lazy.Builder (Builder)
 import qualified Data.Text.Lazy.Builder as TB
 import Nix.Expr hiding (string)
+import Nix.Util (nixKeywords)
 
 newtype PrintContext = PrintContext {pcIndent :: Int}
 
@@ -119,7 +120,10 @@ binding :: (Ident, Printer) -> Printer
 binding (ident, body) = escape ident <> " = " <> body <> ";"
 
 escape :: Text -> Printer
-escape t = if T.all isAlphaNum t then text t else quotes (text t)
+escape t =
+  if T.all isAlphaNum t && not (t `elem` nixKeywords)
+  then text t
+  else quotes (text t)
 
 ppExpr :: Style -> ExprF Printer -> Printer
 ppExpr _ (Var i) = text i

--- a/purenix/src/Nix/Util.hs
+++ b/purenix/src/Nix/Util.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Nix.Util (stripAnnMod) where
+
+import Nix.Prelude
+
+import Language.PureScript.CoreFn (Bind, Module(Module))
+import Language.PureScript.Names (ModuleName)
+
+-- | Strip annotations from a 'Module'.  Helpful for pretty-printing modules for
+-- debugging.
+stripAnnMod :: Module a -> Module ()
+stripAnnMod (Module spn comments name path imports exports reexports foreign' decls) =
+  Module spn comments name path (fmap stripAnnImport imports) exports reexports foreign' (fmap stripAnnBind decls)
+
+-- | Strip annotations from a let or module binding.
+stripAnnBind :: Bind a -> Bind ()
+stripAnnBind = fmap (const ())
+
+-- | Strip an annotation from an import.
+stripAnnImport :: (a, ModuleName) -> ((), ModuleName)
+stripAnnImport (_, modName) = ((), modName)

--- a/purenix/src/Nix/Util.hs
+++ b/purenix/src/Nix/Util.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
 
-module Nix.Util (stripAnnMod) where
+module Nix.Util
+  ( nixKeywords
+  , stripAnnMod
+  ) where
 
 import Nix.Prelude
 
@@ -20,3 +24,9 @@ stripAnnBind = fmap (const ())
 -- | Strip an annotation from an import.
 stripAnnImport :: (a, ModuleName) -> ((), ModuleName)
 stripAnnImport (_, modName) = ((), modName)
+
+-- keywords in nix:
+-- https://github.com/NixOS/nix/blob/90b2dd570cbd8313a8cf45b3cf66ddef2bb06e07/src/libexpr/lexer.l#L115-L124
+nixKeywords :: [Text]
+nixKeywords =
+  ["if", "then", "else", "assert", "with", "let", "in", "rec", "inherit", "or"]


### PR DESCRIPTION
Some various fixups I found while reviewing #5.

Most of these commits are not related, so looking at the commit messages / diffs one-by-one is probably the easiest way to understand them.

Most of these should be non-controversial.  My only worry is the first commit, which switches to `NoImplicitPrelude` and adds a project-wide prelude to our Haskell code.  I think this is nice to clean up common imports, but I'd definitely be willing to go without it if you don't like it.