### PR TITLE
load ffi file

### DIFF
--- a/purenix/purenix.cabal
+++ b/purenix/purenix.cabal
@@ -42,8 +42,10 @@ library
 
   build-depends:
     , aeson
+    , bytestring
     , containers
     , directory
+    , filepath
     , mtl
     , pretty-simple
     , purescript      ==0.14.4

--- a/purenix/src/Lib.hs
+++ b/purenix/src/Lib.hs
@@ -6,16 +6,23 @@ import Nix.Prelude
 
 import Data.Aeson (decode)
 import Data.Aeson.Types (parseEither)
+import qualified Data.ByteString as BS
 import qualified Data.Text as T
+import Data.Text.Encoding (decodeUtf8)
 import Data.Text.Lazy (pack)
 import Data.Text.Lazy.Encoding (encodeUtf8)
 import qualified Data.Text.Lazy.IO as TL
+import Language.PureScript.CoreFn (modulePath)
 import Language.PureScript.CoreFn.FromJSON (moduleFromJSON)
 import Nix.Convert (convert)
 import Nix.Print (renderExpr)
+import Nix.Util (stripAnnMod)
 import System.Directory (createDirectoryIfMissing)
+import Text.Pretty.Simple (pPrint)
+import System.Directory (doesFileExist)
 import qualified System.Environment as Env
 import qualified System.Exit as Sys
+import System.FilePath (replaceExtension)
 
 defaultMain :: IO ()
 defaultMain = do
@@ -30,8 +37,21 @@ defaultMain = do
       case eitherModule of
         Left err -> error err
         Right (_version, mdl) -> do
-          putStrLn "successfully decoded purescript module"
-          nix <- either (Sys.die . T.unpack) (pure . renderExpr) $ convert mdl
+          putStrLn "successfully decoded purescript module:"
+          pPrint (stripAnnMod mdl)
+
+          let ffiFilePath = replaceExtension (modulePath mdl) "nix"
+          doesFfiFileExist <- doesFileExist ffiFilePath
+          maybeFfiFile <-
+            if doesFfiFileExist
+              then
+                -- TODO: decodeUtf8 can throw an exception
+                Just . decodeUtf8 <$> BS.readFile ffiFilePath
+              else pure Nothing
+
+          let eitherNixExpr = convert mdl maybeFfiFile
+          -- pPrint eitherNixExpr
+          nix <- either (Sys.die . T.unpack) (pure . renderExpr) eitherNixExpr
           TL.putStrLn nix
 
           -- TODO: Transform the purescript module into a .nix file

--- a/purenix/src/Lib.hs
+++ b/purenix/src/Lib.hs
@@ -19,7 +19,7 @@ import Nix.Print (renderExpr)
 import Nix.Util (stripAnnMod)
 import System.Directory (createDirectoryIfMissing)
 import Text.Pretty.Simple (pPrint)
-import System.Directory (doesFileExist)
+import System.Directory (doesFileExist, getCurrentDirectory)
 import qualified System.Environment as Env
 import qualified System.Exit as Sys
 import System.FilePath (replaceExtension)
@@ -40,7 +40,7 @@ defaultMain = do
           putStrLn "successfully decoded purescript module:"
           pPrint (stripAnnMod mdl)
 
-          let ffiFilePath = replaceExtension (modulePath mdl) "nix"
+          let ffiFilePath = "../purescript-cabal-parser/" <> replaceExtension (modulePath mdl) "nix"
           doesFfiFileExist <- doesFileExist ffiFilePath
           maybeFfiFile <-
             if doesFfiFileExist

--- a/purenix/src/Lib.hs
+++ b/purenix/src/Lib.hs
@@ -19,7 +19,7 @@ import Nix.Print (renderExpr)
 import Nix.Util (stripAnnMod)
 import System.Directory (createDirectoryIfMissing)
 import Text.Pretty.Simple (pPrint)
-import System.Directory (doesFileExist, getCurrentDirectory)
+import System.Directory (doesFileExist)
 import qualified System.Environment as Env
 import qualified System.Exit as Sys
 import System.FilePath (replaceExtension)

--- a/purenix/src/Nix/Convert.hs
+++ b/purenix/src/Nix/Convert.hs
@@ -6,7 +6,6 @@ module Nix.Convert (convert) where
 
 import Nix.Prelude
 
-import Data.List ((\\))
 import qualified Data.Map as M
 import qualified Data.Text as T
 import Language.PureScript (Ident (..))

--- a/purenix/src/Nix/Expr.hs
+++ b/purenix/src/Nix/Expr.hs
@@ -23,6 +23,7 @@ data ExprF f
   | Let [(Ident, f)] f
   | Num Integer
   | String Text
+  | Raw Text
   deriving stock (Functor, Foldable, Traversable, Show)
 
 data Op = Update
@@ -64,3 +65,6 @@ list = Expr . List
 
 bin :: Op -> Expr -> Expr -> Expr
 bin op a b = Expr $ Bin op a b
+
+raw :: Text -> Expr
+raw = Expr . Raw


### PR DESCRIPTION
Implement basic support for reading in FFI files.

Here's what the generated `.nix` file now looks like:

```nix
modules:
let
  __ffi =
{ mySubstring = builtins.substring; }
; 
  mySubstring = __ffi.mySubstring;
  useMySubstring = modules.Main.mySubstring 0 3 "nixos";
  myId = a: a;
  myNum = modules.Main.myId modules.Dep.myDep;
in
  { inherit myId myNum mySubstring useMySubstring __ffi;
    inherit (modules.Dep) myDep;
  }
```

The `Main.nix` ffi file has been inlined as an `__ffi` let binding.

This presents a basic example of doing FFI, but there are other ways we could approach this.  If we decide to go with this approach, there are definitely some things added in this PR that could be improved.