### PR TITLE
Switch to importing ffi file instead of embedding it raw

### DIFF
--- a/purenix/src/Lib.hs
+++ b/purenix/src/Lib.hs
@@ -40,10 +40,12 @@ defaultMain = do
         Right (_version, mdl) -> do
           putStrLn "successfully decoded purescript module:"
           pPrint (stripAnnMod mdl)
+          let generateDir = "../generated/"
+          createDirectoryIfMissing True generateDir
 
           -- Create the output __ffi.nix file for this module if it has foreign imports.
           let ffiFilePath = "../purescript-cabal-parser/" <> replaceExtension (modulePath mdl) "nix"
-          let ffiOutputFilePath = moduleDir <> "__ffi.nix"
+          let ffiOutputFilePath = generateDir <> modName <> "__ffi.nix"
           doesFfiFileExist <- doesFileExist ffiFilePath
           when doesFfiFileExist $ copyFile ffiFilePath ffiOutputFilePath
 
@@ -53,6 +55,5 @@ defaultMain = do
           TL.putStrLn nix
 
           -- TODO: Transform the purescript module into a .nix file
-          createDirectoryIfMissing True "../generated"
           putStrLn "writing ../generated/Main.nix"
           TL.writeFile "../generated/Main.nix" nix

--- a/purenix/src/Nix/Expr.hs
+++ b/purenix/src/Nix/Expr.hs
@@ -23,7 +23,7 @@ data ExprF f
   | Let [(Ident, f)] f
   | Num Integer
   | String Text
-  | Raw Text
+  | Path Text
   deriving stock (Functor, Foldable, Traversable, Show)
 
 data Op = Update
@@ -66,5 +66,5 @@ list = Expr . List
 bin :: Op -> Expr -> Expr -> Expr
 bin op a b = Expr $ Bin op a b
 
-raw :: Text -> Expr
-raw = Expr . Raw
+path :: Text -> Expr
+path = Expr . Path

--- a/purenix/src/Nix/Print.hs
+++ b/purenix/src/Nix/Print.hs
@@ -89,6 +89,7 @@ exprStyle v = bool Single Multi $ elem Multi v
 exprPrec :: ExprF a -> Int
 exprPrec Var {} = 10
 exprPrec Num {} = 10
+exprPrec Path {} = 10
 exprPrec String {} = 10
 exprPrec Attrs {} = 10
 exprPrec List {} = 10
@@ -100,7 +101,6 @@ exprPrec (Bin op _ _) = opPrec op
     opPrec Update = 5
 exprPrec Abs {} = 0
 exprPrec Let {} = 0
-exprPrec Raw {} = 0
 
 parens :: Bool -> Style -> Printer -> Printer
 parens False _ = id
@@ -110,7 +110,6 @@ parenthesize :: ExprF a -> Int -> Bool
 parenthesize Attrs {} = const False
 parenthesize Let {} = const False
 parenthesize List {} = (< 10)
-parenthesize Raw {} = const True
 parenthesize e = (< exprPrec e)
 
 sepBy :: Printer -> [Printer] -> Printer
@@ -143,6 +142,7 @@ ppExpr sty (List l) = delimit sty '[' ']' $ sepBy newline l
 ppExpr _ (Sel a b) = a <> "." <> escape b
 ppExpr _ (String str) = text str
 ppExpr _ (Num n) = string (show n)
+ppExpr _ (Path t) = text t
 ppExpr _ (Let binds body) =
   mconcat
     [ newline,
@@ -153,4 +153,3 @@ ppExpr _ (Let binds body) =
       indent body
     ]
 ppExpr _ (Bin Update l r) = l <> " // " <> r
-ppExpr _ (Raw t) = text t


### PR DESCRIPTION
This PR switches purenix to `import` the ffi file instead of directly embedding it.

With this PR, our `Main.purs` gets compiled into this `generated/Main.nix`:

```nix
modules: 
let
  __ffi = import ./Main__ffi.nix;
  mySubstring = __ffi.mySubstring;
  useMySubstring = modules.Main.mySubstring 0 3 "nixos";
  myId = a: a;
  myNum = modules.Main.myId modules.Dep.myDep;
in
  { inherit myId myNum mySubstring useMySubstring __ffi;
    inherit (modules.Dep) myDep;
  }
```

The `src/Main.nix` is output directly as `generated/Main__ffi.nix`:

```nix
{ mySubstring = builtins.substring; }
```